### PR TITLE
Add fare types to support Puget Sound fare calculation

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/FareAttribute.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/FareAttribute.java
@@ -45,12 +45,20 @@ public final class FareAttribute extends IdentityBean<AgencyAndId> {
   @CsvField(optional = true)
   private String farePeriodId;
 
+  /** The following are extensions to the GTFS spec to support Seattle fare types. */
+  @CsvField(optional = true)
+  private float youthPrice;
+  
+  @CsvField(optional = true)
+  private float seniorPrice;
+  
   /**
    * This is a proposed extension to the GTFS spec
    */
   @CsvField(optional = true)
   private int journeyDuration = MISSING_VALUE;
 
+  
   public FareAttribute() {
 
   }
@@ -157,6 +165,22 @@ public final class FareAttribute extends IdentityBean<AgencyAndId> {
 
   public void setFarePeriodId(String farePeriodId) {
     this.farePeriodId = farePeriodId;
+  }
+
+  public float getYouthPrice() {
+	return youthPrice;
+  }
+
+  public void setYouthPrice(float youthPrice) {
+	this.youthPrice = youthPrice;
+  }
+
+  public float getSeniorPrice() {
+	return seniorPrice;
+  }
+
+  public void setSeniorPrice(float seniorPrice) {
+	this.seniorPrice = seniorPrice;
   }
 
 }


### PR DESCRIPTION
Add support for extra youth_price and senior_price columns to fare_attributes.txt. This simplifies loading fare data into OpenTripPlanner for the Puget Sound region.

See [discussion](https://groups.google.com/forum/#!topic/opentripplanner-dev/qib4U2wxM8g) on opentripplanner-dev for more information.
