### PR TITLE
Allow transfers.txt transfer_type field to be empty

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Transfer.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/Transfer.java
@@ -48,6 +48,7 @@ public final class Transfer extends IdentityBean<Integer> {
   @CsvField(name = "to_trip_id", mapping = EntityFieldMappingFactory.class, optional = true)
   private Trip toTrip;
 
+  @CsvField(optional = true, defaultValue = "0", alwaysIncludeInOutput = true)
   private int transferType;
 
   @CsvField(optional = true)


### PR DESCRIPTION
According to GTFS spec (https://developers.google.com/transit/gtfs/reference/#transferstxt), while the field (i.e., header) is required, an empty value in a record is considered to be the value 0. This appears to be the root cause of OpenTripPlanner/OpenTripPlanner#1622.
